### PR TITLE
feat: change blockchain type for bid-received to marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@aws-sdk/client-sns": "^3.609.0",
     "@dcl/catalyst-contracts": "^4.4.1",
     "@dcl/platform-server-commons": "^0.0.4",
-    "@dcl/schemas": "^13.0.0",
+    "@dcl/schemas": "^13.4.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^2.1.0",
     "@well-known-components/interfaces": "^1.4.3",

--- a/src/adapters/producers/bid-received.ts
+++ b/src/adapters/producers/bid-received.ts
@@ -103,8 +103,8 @@ export async function bidReceivedProducer(
 
       for (const bid of result.bids) {
         const event: BidReceivedEvent = {
-          type: Events.Type.BLOCKCHAIN,
-          subType: Events.SubType.Blockchain.BID_RECEIVED,
+          type: Events.Type.MARKETPLACE,
+          subType: Events.SubType.Marketplace.BID_RECEIVED,
           key: bid.blockchainId,
           timestamp: bid.createdAt * 1000,
           metadata: {
@@ -131,8 +131,8 @@ export async function bidReceivedProducer(
 
     return {
       event: {
-        type: Events.Type.BLOCKCHAIN,
-        subType: Events.SubType.Blockchain.BID_RECEIVED
+        type: Events.Type.MARKETPLACE,
+        subType: Events.SubType.Marketplace.BID_RECEIVED
       },
       records: produced,
       lastRun: now
@@ -141,8 +141,8 @@ export async function bidReceivedProducer(
 
   return {
     event: {
-      type: Events.Type.BLOCKCHAIN,
-      subType: Events.SubType.Blockchain.BID_RECEIVED
+      type: Events.Type.MARKETPLACE,
+      subType: Events.SubType.Marketplace.BID_RECEIVED
     },
     run
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export type DatabaseComponent = {
 export type IEventProducerResult = {
   event: {
     type: Events.Type
-    subType: Events.SubType.Blockchain
+    subType: Events.SubType.Blockchain | Events.SubType.Marketplace
   }
   records: Event[]
   lastRun: number
@@ -76,7 +76,7 @@ export type IEventGenerator = {
   run(since: number): Promise<IEventProducerResult>
   event: {
     type: Events.Type
-    subType: Events.SubType.Blockchain
+    subType: Events.SubType.Blockchain | Events.SubType.Marketplace
   }
 }
 

--- a/test/unit/producers/bid-received.spec.ts
+++ b/test/unit/producers/bid-received.spec.ts
@@ -46,12 +46,12 @@ describe('bid received producer', () => {
     let result = await producer.run(Date.now())
     expect(result).toMatchObject({
       event: {
-        type: 'blockchain',
+        type: 'marketplace',
         subType: 'bid-received'
       },
       records: [
         {
-          type: 'blockchain',
+          type: 'marketplace',
           subType: 'bid-received',
           key: '0x840df86c97afbeca305f1aa4009496abb48f2a58bf037ee6aaae2d6bd64511dc',
           timestamp: 1701367617000,
@@ -89,7 +89,7 @@ describe('bid received producer', () => {
     let result = await producer.run(Date.now())
     expect(result).toMatchObject({
       event: {
-        type: 'blockchain',
+        type: 'marketplace',
         subType: 'bid-received'
       },
       records: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,10 +774,10 @@
     "@well-known-components/interfaces" "^1.4.2"
     node-fetch "^2.7.0"
 
-"@dcl/schemas@^13.0.0":
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-13.2.2.tgz#8efdcb4ae2915212ba2c3e3725bf69ff4a4278ce"
-  integrity sha512-mQDvLxNL/yoWdmDKFzfpi0xJoPAEmxAoMGzwCVcmiBbP3h5T6S6RjXV9rwkZ8OQKhDURbf6wEQTJc9WF3xEF0g==
+"@dcl/schemas@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-13.4.0.tgz#bf6fe3caf71c77233006b10ed7b896f9e49e4403"
+  integrity sha512-4lxkTQisiT1+6mfHgfOGxM6wDain3+dGnTgCr6wfXUMgOKsF7sUY6FeneUvZpu9Xm4yKYAUnyggPVvkHd6OKWA==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"


### PR DESCRIPTION
Bids will now be created offchain using the marketplace server. This PR changes the type of `bid-created` notification to be `Marketplace` instead of `Blockchain`